### PR TITLE
Add DataTable method.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        php: [7.3, 7.4, 8.0, 8.1, 8.2]
+        php: [8.1, 8.2]
 
     steps:
       - uses: actions/checkout@v3

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3",
+        "php": ">=8.1",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6 || ^7"
     },

--- a/src/DataTableIdentifiers.php
+++ b/src/DataTableIdentifiers.php
@@ -7,11 +7,12 @@ namespace Chromatic\OrangeDam;
  *
  * @see https://example.orangelogic.com/API/DataTable/v2.2/Documents.All:Read
  */
-enum DataTableIdentifiers: string {
-  case SYSTEM_ID = 'CoreField.Identifier';
-  case RECORD_ID = 'RecordID';
-  case CLIENT_ID = 'CoreField.Id_Client';
-  CASE OTHER_NUMBER = 'CoreField.OtherNum';
-  CASE ORIGINAL_FILE_NAME = 'CoreField.OriginalFileName';
-  CASE ORIGINAL_VERSION = 'CoreField.DO_OriginalVersion';
+enum DataTableIdentifiers: string
+{
+    case SYSTEM_ID = 'CoreField.Identifier';
+    case RECORD_ID = 'RecordID';
+    case CLIENT_ID = 'CoreField.Id_Client';
+    case OTHER_NUMBER = 'CoreField.OtherNum';
+    case ORIGINAL_FILE_NAME = 'CoreField.OriginalFileName';
+    case ORIGINAL_VERSION = 'CoreField.DO_OriginalVersion';
 }

--- a/src/DataTableIdentifiers.php
+++ b/src/DataTableIdentifiers.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Chromatic\OrangeDam;
+
+/**
+ * The valid identifier properties for the DataTable API.
+ *
+ * @see https://example.orangelogic.com/API/DataTable/v2.2/Documents.All:Read
+ */
+enum DataTableIdentifiers: string {
+  case SYSTEM_ID = 'CoreField.Identifier';
+  case RECORD_ID = 'RecordID';
+  case CLIENT_ID = 'CoreField.Id_Client';
+  CASE OTHER_NUMBER = 'CoreField.OtherNum';
+  CASE ORIGINAL_FILE_NAME = 'CoreField.OriginalFileName';
+  CASE ORIGINAL_VERSION = 'CoreField.DO_OriginalVersion';
+}

--- a/src/Endpoints/DataTable.php
+++ b/src/Endpoints/DataTable.php
@@ -69,4 +69,21 @@ class DataTable extends Endpoint
             ['form_params' => $params],
         );
     }
+
+  /**
+   * Get data for all document types.
+   *
+   * @param array $params
+   *   Optional parameters.
+   *
+   * @return \Chromatic\OrangeDam\Http\Response
+   */
+    public function getDocumentData(array $params = [])
+    {
+        return $this->client->request(
+            'post',
+            static::API_BASE_PATH . 'Documents.All:Read',
+            ['form_params' => $params],
+        );
+    }
 }

--- a/src/Endpoints/Endpoint.php
+++ b/src/Endpoints/Endpoint.php
@@ -9,7 +9,7 @@ abstract class Endpoint
     /**
      * Client instance.
      *
-     * @var \GuzzleHttp\Client
+     * @var \Chromatic\OrangeDam\Http\Client
      */
     protected $client;
 

--- a/src/Endpoints/OAuth2.php
+++ b/src/Endpoints/OAuth2.php
@@ -35,7 +35,7 @@ class OAuth2 extends Endpoint
 
         $options['headers']['content-type'] = 'application/x-www-form-urlencoded';
 
-        $response = $this->client->request('post', $this->endpoint, $options);
+        $response = $this->client->request('post', $this->endpoint, $options, '', false);
         $data = $response->getData();
 
         if (empty($data->access_token)) {


### PR DESCRIPTION
## Description
- Adds a new DataTable API method.
- Fixes OAuth request to not require Oauth

## Motivation / Context
- We wanted to leverage another API endpoint.
- API requests were failing. ⚠️  I'm unsure how this was working before though.

![Screenshot 2023-08-02 at 6 17 03 PM](https://github.com/ChromaticHQ/orange-dam-php/assets/1349906/9fd45923-9ef9-4317-b622-e5594d8c937c)


## Testing Instructions / How This Has Been Tested
Drush commands that use this library work again.

## Screenshots
<!-- Would including screenshots be helpful to the reviewer? -->

## Documentation
<!-- Do any of the changes warrant documentation updates? -->
