### PR TITLE
Replaced array_merge with array spread operator.

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -118,7 +118,7 @@ class Client
         $url = $endpoint . '?' . $full_query_string;
 
         // Wraps to passed client options.
-        $options = array_merge($this->clientOptions, $options);
+        $options = [...$this->clientOptions, ...$options];
         $options['headers']['User-Agent'] = $this->user_agent;
 
         // Adds OAuth2.0 authentication token to the request.


### PR DESCRIPTION
## Description
Replaced array_merge with array spread operator.

## Motivation / Context
Ensure rector is passing. First surfaced in #19.

## Testing Instructions / How This Has Been Tested
Tests should pass.

## Additional Info
https://github.com/rectorphp/rector/blob/main/docs/rector_rules_overview.md#arrayspreadinsteadofarraymergerector