### PR TITLE
Remove magic Factory::__call() to improve static analysis and legibility of code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
+# Composer
 composer.lock
 vendor/
+# Editors
 .idea
-# Ignore generated PHPUnit files
+# OS detritus
+.DS_Store
+# PHPUnit
 /tests/phpunit
 .phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ composer require "chromatic/orange-dam-php"
 ### Usage
 
 ```php
-use Chromatic\OrangeDam\Factory as OrangeDamClientFactory;
+use Chromatic\OrangeDam\Factory as OrangeDamApi;
 
 // Create client instance.
-$client = new OrangeDamClientFactory([
+$api = new OrangeDamApi([
     'base_path' => 'https://orange-dam-api-server-example.com',
     'query_string' => 'SESSION=XXX',
   ],
@@ -53,11 +53,11 @@ $client = new OrangeDamClientFactory([
 );
 
 // Authenticate with OAuth2.0.
-$tokens = $client->oAuth2()->getTokensByCode(
+$tokens = $api->oAuth2()->getTokensByCode(
   'CLIENT_ID_XXX',
   'CLIENT_SECRET_XXX',
 );
-$client->getClient()->setOauth2Token($tokens->access_token);
+$api->getClient()->setOauth2Token($tokens->access_token);
 
 // Make a search request with given parameters.
 $params = [
@@ -65,6 +65,6 @@ $params = [
   'fields' => 'Title,SystemIdentifier,Caption',
   'format' => 'json',
 ];
-$response = $client->search()->search($params);
+$response = $api->getEndpoint('Search')->search($params);
 $content = $response->getData();
 ```

--- a/src/Exceptions/OrangeDamUnimplementedEndpointException.php
+++ b/src/Exceptions/OrangeDamUnimplementedEndpointException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Chromatic\OrangeDam\Exceptions;
+
+class OrangeDamUnimplementedEndpointException extends \Exception
+{
+}

--- a/src/Exceptions/OrangeDamUnimplementedEndpointException.php
+++ b/src/Exceptions/OrangeDamUnimplementedEndpointException.php
@@ -2,6 +2,21 @@
 
 namespace Chromatic\OrangeDam\Exceptions;
 
+use Chromatic\OrangeDam\Factory;
+
 class OrangeDamUnimplementedEndpointException extends \Exception
 {
+    public function __construct(string $endpoint_name, ?\Throwable $previous)
+    {
+        $message = sprintf(
+            'Endpoint %s does not exist. Compare your endpoint name to
+            the endpoint classes in the Endpoints/ directory. If the
+            Orange Dam Endpoint you wish to use has not been implemented
+            consider contributing an endpoint to
+            %s',
+            escapeshellarg($endpoint_name),
+            Factory::PROJECT_URL,
+        );
+        parent::__construct($message, 0, $previous);
+    }
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -16,7 +16,7 @@ class Factory
     /**
      * Project URL
      */
-    public const PROJECT_URL = 'https://https://github.com/ChromaticHQ/orange-dam-php';
+    final public const PROJECT_URL = 'https://https://github.com/ChromaticHQ/orange-dam-php';
 
     /**
      * Client instance.
@@ -40,14 +40,11 @@ class Factory
         $this->client = $client;
     }
 
-  /**
-   * Returns the Orange DAM API Endpoint requested by name.
-   *
-   * @param string $endpoint_name
-   * @param mixed $args
-   *
-   * @return \Chromatic\OrangeDam\Endpoints\Endpoint
-   */
+    /**
+     * Returns the Orange DAM API Endpoint requested by name.
+     *
+     *
+     */
     public function getEndpoint(string $endpoint_name, mixed $args = []): Endpoint
     {
         $endpoint_class = 'Chromatic\\OrangeDam\\Endpoints\\' . $endpoint_name;
@@ -65,7 +62,6 @@ class Factory
      *
      * Use getEndpoint('AssetLink') instead.
      *
-     * @return \Chromatic\OrangeDam\Endpoints\AssetLink
      * @deprecated
      */
     public function assetLink(): AssetLink
@@ -78,7 +74,6 @@ class Factory
      *
      * Use getEndpoint('DataTable') instead.
      *
-     * @return \Chromatic\OrangeDam\Endpoints\DataTable
      * @deprecated
      */
     public function dataTable(): DataTable
@@ -91,7 +86,6 @@ class Factory
      *
      * Use getEndpoint('MediaFile') instead.
      *
-     * @return \Chromatic\OrangeDam\Endpoints\MediaFile
      * @deprecated
      */
     public function mediaFile(): MediaFile
@@ -104,7 +98,6 @@ class Factory
      *
      * Use getEndpoint('OAuth2') instead.
      *
-     * @return \Chromatic\OrangeDam\Endpoints\OAuth2
      * @deprecated
      */
     public function oAuth2(): OAuth2
@@ -117,7 +110,6 @@ class Factory
      *
      * Use getEndpoint('ObjectManagement') instead.
      *
-     * @return \Chromatic\OrangeDam\Endpoints\ObjectManagement
      * @deprecated
      */
     public function objectManagement(): ObjectManagement
@@ -130,7 +122,6 @@ class Factory
      *
      * Use getEndpoint('Search') instead.
      *
-     * @return \Chromatic\OrangeDam\Endpoints\Search
      * @deprecated
      */
     public function search(): Search
@@ -141,7 +132,6 @@ class Factory
     /**
      * Returns an Orange DAM client instance.
      *
-     * @return Client
      *   An Orange DAM Client instance.
      */
     public function getClient(): Client

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -53,8 +53,7 @@ class Factory
         $endpoint_class = 'Chromatic\\OrangeDam\\Endpoints\\' . $endpoint_name;
         try {
             $endpoint = new $endpoint_class($this->client, ...$args);
-        }
-        catch (\Exception $e) {
+        } catch (\Exception $e) {
             $message = sprintf(
                 "Endpoint %s does not exist. Compare your endpoint name to\n
                 the endpoint classes in the Endpoints/ directory. If the \n

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -54,7 +54,7 @@ class Factory
         try {
             $endpoint = new $endpoint_class($this->client, ...$args);
         } catch (\Throwable $e) {
-            throw new OrangeDamUnimplementedEndpointException($endpoint_name, $previous);
+            throw new OrangeDamUnimplementedEndpointException($endpoint_name, $e);
         }
 
         return $endpoint;

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -2,18 +2,23 @@
 
 namespace Chromatic\OrangeDam;
 
+use Chromatic\OrangeDam\Endpoints\{AssetLink, DataTable, Endpoint, MediaFile, OAuth2, ObjectManagement, Search};
+use Chromatic\OrangeDam\Exceptions\{OrangeDamException, OrangeDamUnimplementedEndpointException};
 use Chromatic\OrangeDam\Http\Client;
-use Chromatic\OrangeDam\Endpoints\Endpoint;
-use Chromatic\OrangeDam\Exceptions\OrangeDamException;
 
 /**
  * Class Factory.
  *
- * @method \Chromatic\OrangeDam\Endpoints\Search       search()
- * @method \Chromatic\OrangeDam\Endpoints\OAuth2       oAuth2()
- */
+ * Manages the connection to Orange DAM API and a library of endpoints.
+*/
 class Factory
 {
+
+    /**
+     * Project URL
+     */
+    const PROJECT_URL = 'https://https://github.com/ChromaticHQ/orange-dam-php';
+
     /**
      * Client instance.
      *
@@ -36,21 +41,108 @@ class Factory
         $this->client = $client;
     }
 
-    /**
-     * Return an instance of a Endpoint based on the method called.
-     */
-    public function __call(string $name, mixed $args): Endpoint
-    {
-        $endpoint = 'Chromatic\\OrangeDam\\Endpoints\\' . ucfirst($name);
+  /**
+   * Returns the Orange DAM API Endpoint requested by name.
+   *
+   * @param string $endpoint_name
+   * @param mixed $args
+   *
+   * @return \Chromatic\OrangeDam\Endpoints\Endpoint
+   */
+    public function getEndpoint(string $endpoint_name, mixed $args = []): Endpoint {
+      $endpoint_class = 'Chromatic\\OrangeDam\\Endpoints\\' . $endpoint_name. 'X';
+      try {
+        $endpoint = new $endpoint_class($this->client, ...$args);
+      }
+      catch (\Exception $e) {
+        $message = sprintf('Endpoint %s does not exist. Compare your endpoint name to the endpoint classes in the Endpoints/ directory.
+        If the Orange Dam endpoint you wish to use has not been implemented consider contributing an endpoint to %s',
+          htmlspecialchars(escapeshellarg($endpoint_name)),
+          static::PROJECT_URL,
+        );
+        throw new OrangeDamUnimplementedEndpointException($message);
+      }
 
-        return new $endpoint($this->client, ...$args);
+      return $endpoint;
     }
 
     /**
-     * Returns client instance.
+     * Returns an Orange Dam API AssetLink endpoint.
+     *
+     * Use getEndpoint('AssetLink') instead.
+     *
+     * @return \Chromatic\OrangeDam\Endpoints\AssetLink
+     * @deprecated
+     */
+    public function assetLink(): AssetLink {
+      return $this->getEndpoint('AssetLink');
+    }
+
+    /**
+     * Returns an Orange Dam API DataTable endpoint.
+     *
+     * Use getEndpoint('DataTable') instead.
+     *
+     * @return \Chromatic\OrangeDam\Endpoints\DataTable
+     * @deprecated
+     */
+    public function dataTable(): DataTable {
+      return $this->getEndpoint('DataTable');
+    }
+
+    /**
+     * Returns an Orange Dam API MediaFile endpoint.
+     *
+     * Use getEndpoint('MediaFile') instead.
+     *
+     * @return \Chromatic\OrangeDam\Endpoints\MediaFile
+     * @deprecated
+     */
+    public function mediaFile(): MediaFile {
+      return $this->getEndpoint('MediaFile');
+    }
+
+    /**
+     * Returns an Orange Dam API OAuth2 endpoint.
+     *
+     * Use getEndpoint('OAuth2') instead.
+     *
+     * @return \Chromatic\OrangeDam\Endpoints\OAuth2
+     * @deprecated
+     */
+    public function oAuth2(): OAuth2 {
+      return $this->getEndpoint('OAuth2');
+    }
+
+    /**
+     * Returns an Orange Dam API ObjectManagement endpoint.
+     *
+     * Use getEndpoint('ObjectManagement') instead.
+     *
+     * @return \Chromatic\OrangeDam\Endpoints\ObjectManagement
+     * @deprecated
+     */
+    public function objectManagement(): ObjectManagement {
+      return $this->getEndpoint('ObjectManagement');
+    }
+
+    /**
+     * Returns an Orange Dam API Search endpoint.
+     *
+     * Use getEndpoint('Search') instead.
+     *
+     * @return \Chromatic\OrangeDam\Endpoints\Search
+     * @deprecated
+     */
+    public function search(): Search {
+      return $this->getEndpoint('Search');
+    }
+
+    /**
+     * Returns an Orange DAM client instance.
      *
      * @return Client
-     *   Client instance.
+     *   An Orange DAM Client instance.
      */
     public function getClient(): Client
     {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -13,18 +13,17 @@ use Chromatic\OrangeDam\Http\Client;
 */
 class Factory
 {
-
     /**
      * Project URL
      */
-    const PROJECT_URL = 'https://https://github.com/ChromaticHQ/orange-dam-php';
+    protected const PROJECT_URL = 'https://https://github.com/ChromaticHQ/orange-dam-php';
 
     /**
      * Client instance.
      *
-     * @var Client
+     * @var \Chromatic\OrangeDam\Http\Client
      */
-    protected $client;
+    protected Client $client;
 
     /**
      * Constructor.
@@ -49,15 +48,18 @@ class Factory
    *
    * @return \Chromatic\OrangeDam\Endpoints\Endpoint
    */
-    public function getEndpoint(string $endpoint_name, mixed $args = []): Endpoint {
-        $endpoint_class = 'Chromatic\\OrangeDam\\Endpoints\\' . $endpoint_name. 'X';
+    public function getEndpoint(string $endpoint_name, mixed $args = []): Endpoint
+    {
+        $endpoint_class = 'Chromatic\\OrangeDam\\Endpoints\\' . $endpoint_name;
         try {
             $endpoint = new $endpoint_class($this->client, ...$args);
         }
         catch (\Exception $e) {
             $message = sprintf(
-                "Endpoint %s does not exist. Compare your endpoint name to the endpoint classes in the Endpoints/ directory.\n
-                If the Orange Dam endpoint you wish to use has not been implemented consider contributing an endpoint to %s",
+                "Endpoint %s does not exist. Compare your endpoint name to\n
+                the endpoint classes in the Endpoints/ directory. If the \n
+                Orange Dam Endpoint you wish to use has not been implemented\n
+                consider contributing an endpoint to %s",
                 htmlspecialchars(escapeshellarg($endpoint_name)),
                 static::PROJECT_URL,
             );
@@ -75,7 +77,8 @@ class Factory
      * @return \Chromatic\OrangeDam\Endpoints\AssetLink
      * @deprecated
      */
-    public function assetLink(): AssetLink {
+    public function assetLink(): AssetLink
+    {
         return $this->getEndpoint('AssetLink');
     }
 
@@ -87,7 +90,8 @@ class Factory
      * @return \Chromatic\OrangeDam\Endpoints\DataTable
      * @deprecated
      */
-    public function dataTable(): DataTable {
+    public function dataTable(): DataTable
+    {
         return $this->getEndpoint('DataTable');
     }
 
@@ -99,7 +103,8 @@ class Factory
      * @return \Chromatic\OrangeDam\Endpoints\MediaFile
      * @deprecated
      */
-    public function mediaFile(): MediaFile {
+    public function mediaFile(): MediaFile
+    {
         return $this->getEndpoint('MediaFile');
     }
 
@@ -111,7 +116,8 @@ class Factory
      * @return \Chromatic\OrangeDam\Endpoints\OAuth2
      * @deprecated
      */
-    public function oAuth2(): OAuth2 {
+    public function oAuth2(): OAuth2
+    {
         return $this->getEndpoint('OAuth2');
     }
 
@@ -123,7 +129,8 @@ class Factory
      * @return \Chromatic\OrangeDam\Endpoints\ObjectManagement
      * @deprecated
      */
-    public function objectManagement(): ObjectManagement {
+    public function objectManagement(): ObjectManagement
+    {
         return $this->getEndpoint('ObjectManagement');
     }
 
@@ -135,7 +142,8 @@ class Factory
      * @return \Chromatic\OrangeDam\Endpoints\Search
      * @deprecated
      */
-    public function search(): Search {
+    public function search(): Search
+    {
         return $this->getEndpoint('Search');
     }
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -20,8 +20,6 @@ class Factory
 
     /**
      * Client instance.
-     *
-     * @var \Chromatic\OrangeDam\Http\Client
      */
     protected Client $client;
 
@@ -42,8 +40,6 @@ class Factory
 
     /**
      * Returns the Orange DAM API Endpoint requested by name.
-     *
-     *
      */
     public function getEndpoint(string $endpoint_name, mixed $args = []): Endpoint
     {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -14,7 +14,7 @@ use Chromatic\OrangeDam\Http\Client;
 class Factory
 {
     /**
-     * Project URL
+     * Project URL.
      */
     final public const PROJECT_URL = 'https://https://github.com/ChromaticHQ/orange-dam-php';
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -16,7 +16,7 @@ class Factory
     /**
      * Project URL
      */
-    protected const PROJECT_URL = 'https://https://github.com/ChromaticHQ/orange-dam-php';
+    public const PROJECT_URL = 'https://https://github.com/ChromaticHQ/orange-dam-php';
 
     /**
      * Client instance.
@@ -53,16 +53,8 @@ class Factory
         $endpoint_class = 'Chromatic\\OrangeDam\\Endpoints\\' . $endpoint_name;
         try {
             $endpoint = new $endpoint_class($this->client, ...$args);
-        } catch (\Exception $e) {
-            $message = sprintf(
-                "Endpoint %s does not exist. Compare your endpoint name to\n
-                the endpoint classes in the Endpoints/ directory. If the \n
-                Orange Dam Endpoint you wish to use has not been implemented\n
-                consider contributing an endpoint to %s",
-                htmlspecialchars(escapeshellarg($endpoint_name)),
-                static::PROJECT_URL,
-            );
-            throw new OrangeDamUnimplementedEndpointException($message);
+        } catch (\Throwable $e) {
+            throw new OrangeDamUnimplementedEndpointException($endpoint_name, $previous);
         }
 
         return $endpoint;

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -50,20 +50,21 @@ class Factory
    * @return \Chromatic\OrangeDam\Endpoints\Endpoint
    */
     public function getEndpoint(string $endpoint_name, mixed $args = []): Endpoint {
-      $endpoint_class = 'Chromatic\\OrangeDam\\Endpoints\\' . $endpoint_name. 'X';
-      try {
-        $endpoint = new $endpoint_class($this->client, ...$args);
-      }
-      catch (\Exception $e) {
-        $message = sprintf('Endpoint %s does not exist. Compare your endpoint name to the endpoint classes in the Endpoints/ directory.
-        If the Orange Dam endpoint you wish to use has not been implemented consider contributing an endpoint to %s',
-          htmlspecialchars(escapeshellarg($endpoint_name)),
-          static::PROJECT_URL,
-        );
-        throw new OrangeDamUnimplementedEndpointException($message);
-      }
+        $endpoint_class = 'Chromatic\\OrangeDam\\Endpoints\\' . $endpoint_name. 'X';
+        try {
+            $endpoint = new $endpoint_class($this->client, ...$args);
+        }
+        catch (\Exception $e) {
+            $message = sprintf(
+                "Endpoint %s does not exist. Compare your endpoint name to the endpoint classes in the Endpoints/ directory.\n
+                If the Orange Dam endpoint you wish to use has not been implemented consider contributing an endpoint to %s",
+                htmlspecialchars(escapeshellarg($endpoint_name)),
+                static::PROJECT_URL,
+            );
+            throw new OrangeDamUnimplementedEndpointException($message);
+        }
 
-      return $endpoint;
+        return $endpoint;
     }
 
     /**
@@ -75,7 +76,7 @@ class Factory
      * @deprecated
      */
     public function assetLink(): AssetLink {
-      return $this->getEndpoint('AssetLink');
+        return $this->getEndpoint('AssetLink');
     }
 
     /**
@@ -87,7 +88,7 @@ class Factory
      * @deprecated
      */
     public function dataTable(): DataTable {
-      return $this->getEndpoint('DataTable');
+        return $this->getEndpoint('DataTable');
     }
 
     /**
@@ -99,7 +100,7 @@ class Factory
      * @deprecated
      */
     public function mediaFile(): MediaFile {
-      return $this->getEndpoint('MediaFile');
+        return $this->getEndpoint('MediaFile');
     }
 
     /**
@@ -111,7 +112,7 @@ class Factory
      * @deprecated
      */
     public function oAuth2(): OAuth2 {
-      return $this->getEndpoint('OAuth2');
+        return $this->getEndpoint('OAuth2');
     }
 
     /**
@@ -123,7 +124,7 @@ class Factory
      * @deprecated
      */
     public function objectManagement(): ObjectManagement {
-      return $this->getEndpoint('ObjectManagement');
+        return $this->getEndpoint('ObjectManagement');
     }
 
     /**
@@ -135,7 +136,7 @@ class Factory
      * @deprecated
      */
     public function search(): Search {
-      return $this->getEndpoint('Search');
+        return $this->getEndpoint('Search');
     }
 
     /**


### PR DESCRIPTION
Replaced `__call()` with explicit methods for all Endpoint classes, marked those explicit methods deprecated, and added `getEndpoint()` as the future desired implementation.

Resolves: #23

### Known Issue
The following attempt to raise a helpful message on unimplemented Endpoint classes ends up triggering output three times instead of once. I like the idea of the helpful contribution message but there must be a cleaner way to do it. 

```php
        try {
            $endpoint = new $endpoint_class($this->client, ...$args);
        } catch (\Throwable $e) {
            throw new OrangeDamUnimplementedEndpointException($endpoint_name, $previous);
        }

```