### PR TITLE
Add AssetFile endpoint for retrieving file streams

### DIFF
--- a/src/Endpoints/AssetFile.php
+++ b/src/Endpoints/AssetFile.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Chromatic\OrangeDam\Endpoints;
+
+class AssetFile extends Endpoint
+{
+    /**
+     * API base path.
+     *
+     * @var string
+     */
+    protected const API_BASE_PATH = '/webapi/mediafile/assetfile/';
+
+    /**
+     * Create links to formatted assets.
+     *
+     * @param string $format
+     *   An Orange Dam asset format, such as TR1, or TR1_WATERMARKED.
+     * @param string $sort
+     *   The sort order of found assets. If you are using an identifer, the
+     *   result should just be one listing. The API default is 'Newest First'.
+     * @param array $queryConditions
+     *   An array of searchkeys and searchvalues with which to perform a Search
+     *   API syntax freetext search.
+     *   Example: ['docType' => 'Image',  'Test.UserFieldA' => 'ZZZ']
+     *
+     * @return \Chromatic\OrangeDam\Http\Response
+     */
+    public function getFormatFile(string $format, string $sort = '', array $queryConditions = [])
+    {
+        // @todo Is it over-reach to validate the format against some retrieved
+        // list of formats?
+        $query_string = "Format=$format";
+        if ($sort) {
+            $query_string .= '&Sort=' . rawurlencode($sort);
+        }
+        if ($queryConditions) {
+            $query_string .= '&QueryConditions=';
+            array_walk($queryConditions, fn (&$v, $k) => $v = "$k:$v");
+            $query_string .= rawurlencode(implode(' AND ', $queryConditions));
+        }
+        return $this->client->request(
+            method: 'get',
+            endpoint: static::API_BASE_PATH . 'getassetfile_42R_v1',
+            query_string: $query_string,
+        );
+    }
+}

--- a/src/Endpoints/AssetFile.php
+++ b/src/Endpoints/AssetFile.php
@@ -24,25 +24,29 @@ class AssetFile extends Endpoint
      *   API syntax freetext search.
      *   Example: ['docType' => 'Image',  'Test.UserFieldA' => 'ZZZ']
      *
+     * @see https://jfklibrary5355prod.orangelogic.com/swagger/index.html?
+     *   urls.primaryName=mediafile#/AssetFile/
+     *   get_webapi_mediafile_assetfile_getassetfile_42R_v1
+     *
      * @return \Chromatic\OrangeDam\Http\Response
      */
     public function getFormatFile(string $format, string $sort = '', array $queryConditions = [])
     {
-        // @todo Decide whether we should be validating the sort keys and
-        //   the formats against retrieved or static lists.
-        $query_string = "Format=$format";
+        $query = [
+          'Format' => $format,
+        ];
         if ($sort) {
-            $query_string .= '&Sort=' . rawurlencode($sort);
+            $query['Sort'] = $sort;
         }
         if ($queryConditions) {
-            $query_string .= '&QueryConditions=';
             array_walk($queryConditions, fn (&$v, $k) => $v = "$k:$v");
-            $query_string .= rawurlencode(implode(' AND ', $queryConditions));
+            $query['QueryConditions'] = implode(' AND ', $queryConditions);
         }
+
         return $this->client->request(
             method: 'get',
             endpoint: static::API_BASE_PATH . 'getassetfile_42R_v1',
-            query_string: $query_string,
+            query_string: http_build_query(data: $query, encoding_type: PHP_QUERY_RFC3986),
         );
     }
 }

--- a/src/Endpoints/AssetFile.php
+++ b/src/Endpoints/AssetFile.php
@@ -28,8 +28,8 @@ class AssetFile extends Endpoint
      */
     public function getFormatFile(string $format, string $sort = '', array $queryConditions = [])
     {
-        // @todo Is it over-reach to validate the format against some retrieved
-        // list of formats?
+        // @todo Decide whether we should be validating the sort keys and
+        //   the formats against retrieved or static lists.
         $query_string = "Format=$format";
         if ($sort) {
             $query_string .= '&Sort=' . rawurlencode($sort);

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -2,7 +2,14 @@
 
 namespace Chromatic\OrangeDam;
 
-use Chromatic\OrangeDam\Endpoints\{AssetLink, DataTable, Endpoint, MediaFile, OAuth2, ObjectManagement, Search};
+use Chromatic\OrangeDam\Endpoints\{AssetFile,
+  AssetLink,
+  DataTable,
+  Endpoint,
+  MediaFile,
+  OAuth2,
+  ObjectManagement,
+  Search};
 use Chromatic\OrangeDam\Exceptions\OrangeDamException;
 use Chromatic\OrangeDam\Http\Client;
 
@@ -36,6 +43,11 @@ class Factory
             $client = new Client($config, null, $clientOptions);
         }
         $this->client = $client;
+    }
+
+    public function assetFile(): AssetFile
+    {
+        return new AssetFile($this->client);
     }
 
     /**

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -45,6 +45,11 @@ class Factory
         $this->client = $client;
     }
 
+    /**
+     * Returns an Orange DAM API AssetFile endpoint.
+     *
+     * AssetFile streams back the requested file based on search criteria.
+     */
     public function assetFile(): AssetFile
     {
         return new AssetFile($this->client);
@@ -52,6 +57,8 @@ class Factory
 
     /**
      * Returns an Orange Dam API AssetLink endpoint.
+     *
+     * AssetLink returns a URL based on the requested parameters.
      */
     public function assetLink(): AssetLink
     {

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -29,7 +29,6 @@ class Response implements ResponseInterface
     public function __construct(ResponseInterface $response)
     {
         $this->response = $response;
-        $this->data = $this->getDataFromResponse($response);
     }
 
     /**
@@ -43,7 +42,7 @@ class Response implements ResponseInterface
      */
     public function __get($name)
     {
-        return $this->data->{$name};
+        return $this->getData()->{$name};
     }
 
     /**
@@ -54,6 +53,9 @@ class Response implements ResponseInterface
      */
     public function getData()
     {
+        if (is_null($this->data)) {
+            $this->data = $this->getDataFromResponse($this->response);
+        }
         return $this->data;
     }
 
@@ -87,6 +89,14 @@ class Response implements ResponseInterface
     public function getBody(): StreamInterface
     {
         return $this->response->getBody();
+    }
+
+    /**
+     * If there is no stream, consider it an empty response.
+     */
+    public function isEmpty(): bool
+    {
+        return is_null($this->response->getBody()->getSize());
     }
 
     /**

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -16,8 +16,8 @@ final class ResponseTest extends TestCase
     public function testDefaultConstructor(): void
     {
         $response = new Response(new GuzzleResponse());
-        $this->assertSame(null, $response->getData());
-        $this->assertSame(null, $response->toArray());
+        $this->assertNull($response->getData());
+        $this->assertNull($response->toArray());
         $this->assertInstanceOf(StreamInterface::class, $response->getBody());
         $this->assertInstanceOf(ResponseInterface::class, $response->withStatus(200));
         $this->assertSame(200, $response->getStatusCode());


### PR DESCRIPTION
Resolves #35

## Description
This merge request adds a new Endpoint for retrieving file streams. Some file formats, such as watermarked assets, do not return a URL via the AssetLink Endpoint. In order to handle assets that have not been pre-generated and do not have a link, we need to use the AssetFile endpoint `/webapi/mediafile/assetfile/getassetfile_42R_v1`.

We also need to refactor the Response object to no longer assume all responses have JSON data. The Response object can contain a stream resource with binary data instead, so decoding the body will throw an exception.

This is a requirement/blocker for this `orange_dam` issue: https://www.drupal.org/project/orange_dam/issues/3451497

