### PR TITLE
Capture the request data to the response to enable logging and troubleshooting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@2.30.5
+        uses: shivammathur/setup-php@2.31.1
         with:
           php-version: ${{ matrix.php }}
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,4 @@
 parameters:
-    checkMissingIterableValueType: false
     customRulesetUsed: true
     level: 1
     reportUnmatchedIgnoredErrors: true

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -41,11 +41,9 @@ class Client
     public $oauth2;
 
     /**
-     * Client instance.
-     *
-     * @var \GuzzleHttp\Client
+     * The http request client.
      */
-    public $client;
+    public GuzzleClient $httpClient;
 
     /**
      * Guzzle allows options into its request method. Prepare for some defaults.
@@ -59,14 +57,14 @@ class Client
      *
      * @var string
      */
-    protected $user_agent = 'Chromatic_OrangeDam_PHP/1.0.0 (https://github.com/ChromaticHQ/orange-dam-php)';
+    protected $user_agent = 'Chromatic_OrangeDam_PHP (https://github.com/ChromaticHQ/orange-dam-php)';
 
     /**
      * Constructor.
      *
      * @throws \Chromatic\OrangeDam\Exceptions\OrangeDamException
      */
-    public function __construct(array $config = [], GuzzleClient $client = null, array $clientOptions = [])
+    public function __construct(array $config = [], GuzzleClient $httpClient = null, array $clientOptions = [])
     {
         // Set default property values.
         $this->token = null;
@@ -80,14 +78,14 @@ class Client
         }
 
         // Creates a new instance
-        if (is_null($client)) {
-            $client = new GuzzleClient([
+        if (is_null($httpClient)) {
+            $httpClient = new GuzzleClient([
                 'cookies' => true,
                 'timeout' => self::REQUEST_TIMEOUT,
                 'base_uri' => $config['base_path'],
             ]);
         }
-        $this->client = $client;
+        $this->httpClient = $httpClient;
     }
 
     /**
@@ -128,7 +126,7 @@ class Client
 
         try {
             // Make a request with given parameters.
-            return new Response($this->client->request($method, $url, $options));
+            return new Response($this->httpClient, $method, $url, $options);
         } catch (ServerException $e) {
             throw OrangeDamException::create($e);
         } catch (ClientException $e) {

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -108,15 +108,17 @@ class Response implements ResponseInterface
     /**
      * Returns the request string that created this response.
      */
-    public function getRequest(): string {
-      return $this->request;
+    public function getRequest(): string
+    {
+        return $this->request;
     }
 
     /**
      * Returns the request options array that created this response.
      */
-    public function getRequestOptions(): array {
-      return $this->requestOptions;
+    public function getRequestOptions(): array
+    {
+        return $this->requestOptions;
     }
 
     /**

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -15,6 +15,10 @@ class Response implements ResponseInterface
      */
     public $data;
 
+    protected string $request;
+
+    protected array $requestOptions;
+
     /**
      * Response instance.
      *
@@ -26,9 +30,11 @@ class Response implements ResponseInterface
      * Constructor.
      *
      */
-    public function __construct(ResponseInterface $response)
+    public function __construct(\GuzzleHttp\ClientInterface $client, string $method, string $url, array $options = [])
     {
-        $this->response = $response;
+        $this->response = $client->request($method, $url, $options);
+        $this->request = sprintf('%s %s', $method, $url);
+        $this->requestOptions = $options;
     }
 
     /**
@@ -97,6 +103,20 @@ class Response implements ResponseInterface
     public function isEmpty(): bool
     {
         return is_null($this->response->getBody()->getSize());
+    }
+
+    /**
+     * Returns the request string that created this response.
+     */
+    public function getRequest(): string {
+      return $this->request;
+    }
+
+    /**
+     * Returns the request options array that created this response.
+     */
+    public function getRequestOptions(): array {
+      return $this->requestOptions;
     }
 
     /**

--- a/tests/Http/ClientTest.php
+++ b/tests/Http/ClientTest.php
@@ -17,7 +17,7 @@ final class ClientTest extends TestCase
         $client = new Client([
             'base_path' => 'https://test.com',
         ]);
-        $this->assertInstanceOf(GuzzleClient::class, $client->client);
+        $this->assertInstanceOf(GuzzleClient::class, $client->httpClient);
     }
 
     /**

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -2,6 +2,8 @@
 
 namespace Chromatic\OrangeDam\Http;
 
+use Chromatic\OrangeDam\Endpoints\Search;
+use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Psr7\Response as GuzzleResponse;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\MessageInterface;
@@ -15,7 +17,11 @@ final class ResponseTest extends TestCase
      */
     public function testDefaultConstructor(): void
     {
-        $response = new Response(new GuzzleResponse());
+        $clientMock = $this->getMockBuilder(GuzzleClient::class)
+            ->setMethods(['request'])
+            ->getMock();
+        $clientMock->method('request')->willReturn(new GuzzleResponse());
+        $response = new Response($clientMock, 'GET', '');
         $this->assertNull($response->getData());
         $this->assertNull($response->toArray());
         $this->assertInstanceOf(StreamInterface::class, $response->getBody());
@@ -35,7 +41,11 @@ final class ResponseTest extends TestCase
      */
     public function testHeaders(): void
     {
-        $response = new Response(new GuzzleResponse(200, ['Foo' => 'Bar']));
+        $clientMock = $this->getMockBuilder(GuzzleClient::class)
+            ->setMethods(['request'])
+            ->getMock();
+        $clientMock->method('request')->willReturn(new GuzzleResponse(200, ['Foo' => 'Bar']));
+        $response = new Response($clientMock, 'POST', '/');
         $headers = $response->getHeaders();
         $this->assertTrue($response->hasHeader('Foo'));
         $this->assertSame('Bar', $response->getHeaderLine('Foo'));

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -18,7 +18,7 @@ final class ResponseTest extends TestCase
     public function testDefaultConstructor(): void
     {
         $clientMock = $this->getMockBuilder(GuzzleClient::class)
-            ->setMethods(['request'])
+            ->onlyMethods(['request'])
             ->getMock();
         $clientMock->method('request')->willReturn(new GuzzleResponse());
         $response = new Response($clientMock, 'GET', '');
@@ -42,7 +42,7 @@ final class ResponseTest extends TestCase
     public function testHeaders(): void
     {
         $clientMock = $this->getMockBuilder(GuzzleClient::class)
-            ->setMethods(['request'])
+            ->onlyMethods(['request'])
             ->getMock();
         $clientMock->method('request')->willReturn(new GuzzleResponse(200, ['Foo' => 'Bar']));
         $response = new Response($clientMock, 'POST', '/');


### PR DESCRIPTION
## Description
In this merge request we add the API request data to our custom response object so that any caller who receives a response will be able to see the exact request data that produced the response. This can be helpful for diagnostics and troubleshooting,.

## Motivation / Context
Greater insight into what the API is doing.

Resolves #39 

## Testing Instructions / How This Has Been Tested
<!-- Describe how you tested your changes and/or how a reviewer can test your changes. --

## Screenshots
<!-- Would including screenshots be helpful to the reviewer? -->

## Documentation
<!-- Do any of the changes warrant documentation updates? -->
