### PR TITLE
Add support and testing for php 8.3, 8.4, 8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        php: [8.1, 8.2]
+        php: [8.1, 8.2, 8.3, 8.4, 8.5]
 
     steps:
       - uses: actions/checkout@v4

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -37,7 +37,7 @@ class Factory
      *
      * @throws OrangeDamException
      */
-    public function __construct(array $config = [], Client $client = null, array $clientOptions = [])
+    public function __construct(array $config = [], ?Client $client, array $clientOptions = [])
     {
         if (is_null($client)) {
             $client = new Client($config, null, $clientOptions);

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -37,7 +37,7 @@ class Factory
      *
      * @throws OrangeDamException
      */
-    public function __construct(array $config = [], ?Client $client = NULL, array $clientOptions = [])
+    public function __construct(array $config = [], ?Client $client = null, array $clientOptions = [])
     {
         if (is_null($client)) {
             $client = new Client($config, null, $clientOptions);

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -37,7 +37,7 @@ class Factory
      *
      * @throws OrangeDamException
      */
-    public function __construct(array $config = [], ?Client $client, array $clientOptions = [])
+    public function __construct(array $config = [], ?Client $client = NULL, array $clientOptions = [])
     {
         if (is_null($client)) {
             $client = new Client($config, null, $clientOptions);

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -64,7 +64,7 @@ class Client
      *
      * @throws \Chromatic\OrangeDam\Exceptions\OrangeDamException
      */
-    public function __construct(array $config = [], ?GuzzleClient $httpClient, array $clientOptions = [])
+    public function __construct(array $config = [], ?GuzzleClient $httpClient = NULL, array $clientOptions = [])
     {
         // Set default property values.
         $this->token = null;

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -64,7 +64,7 @@ class Client
      *
      * @throws \Chromatic\OrangeDam\Exceptions\OrangeDamException
      */
-    public function __construct(array $config = [], GuzzleClient $httpClient = null, array $clientOptions = [])
+    public function __construct(array $config = [], ?GuzzleClient $httpClient, array $clientOptions = [])
     {
         // Set default property values.
         $this->token = null;

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -64,7 +64,7 @@ class Client
      *
      * @throws \Chromatic\OrangeDam\Exceptions\OrangeDamException
      */
-    public function __construct(array $config = [], ?GuzzleClient $httpClient = NULL, array $clientOptions = [])
+    public function __construct(array $config = [], ?GuzzleClient $httpClient = null, array $clientOptions = [])
     {
         // Set default property values.
         $this->token = null;


### PR DESCRIPTION
## Description
This adds testing for 8.3, 8.4, and 8.5 which are the mainline php versions now.

Should we consider demoting 8.1? composer.json requires 8.1. Removing support for it would require a new major release. If we can live with keeping 8.1 without holding us back, I would keep it for now. 

## Motivation / Context
Keeping code up to date, in order to ease ongoing maintenance.

