### PR TITLE
Resolve circular dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,10 +33,10 @@
     "minimum-stability": "stable",
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-        "phpstan/phpstan-deprecation-rules": "^1.1",
-        "phpstan/extension-installer": "^1.3",
-        "rector/rector": "^1.0.0",
-        "phpunit/phpunit": "^9 || ^10 || ^11 || ^12 || ^13"
+        "phpunit/phpunit": "^9 || ^10 || ^11 || ^12 || ^13",
+        "rector/rector": "^2.3",
+        "phpstan/extension-installer": "^1.4",
+        "phpstan/phpstan-deprecation-rules": "^2.0"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -33,10 +33,10 @@
     "minimum-stability": "stable",
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-        "phpunit/phpunit": "^9 || ^10 || ^11 || ^12 || ^13",
         "rector/rector": "^2.3",
         "phpstan/extension-installer": "^1.4",
-        "phpstan/phpstan-deprecation-rules": "^2.0"
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpunit/phpunit": "^9 || ^10 || ^11 || ^12 || ^13"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
## Description

The attempt to [update rector to v2](https://github.com/ChromaticHQ/orange-dam-php/pull/43) conflicts with the attempt to [update phpstan/phpstan-deprecation-rules to v2](https://github.com/ChromaticHQ/orange-dam-php/pull/42). 

This branch removes both dependencies and re-installs them from scratch in order for the circular dependencies to be resolved. 


## Motivation / Context
Resolves #43 and #42 

Keeping code up-to-date.

## Testing Instructions / How This Has Been Tested
Run tests `composer test`