### PR TITLE
fix: remove duplicate https:// prefix from PROJECT_URL

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -23,7 +23,7 @@ class Factory
     /**
      * Project URL.
      */
-    final public const PROJECT_URL = 'https://https://github.com/ChromaticHQ/orange-dam-php';
+    final public const PROJECT_URL = 'https://github.com/ChromaticHQ/orange-dam-php';
 
     /**
      * Client instance.

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -17,4 +17,9 @@ final class FactoryTest extends TestCase
         ]);
         $this->assertInstanceOf(Factory::class, $factory);
     }
+
+    public function testProjectUrlIsValid(): void
+    {
+        $this->assertStringStartsWith('https://github.com/', Factory::PROJECT_URL);
+    }
 }


### PR DESCRIPTION
## Description
Remove duplicate https:// prefix from PROJECT_URL

## Motivation / Context
Incorrect URL

## Testing Instructions / How This Has Been Tested
Tests should pass. 

Blocked by #54 