### PR TITLE
fix: avoid trailing ? when no query string present

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -113,7 +113,10 @@ class Client
         if (!empty($query_string)) {
             $full_query_string = !empty($full_query_string) ? $full_query_string . '&' . $query_string : $query_string;
         }
-        $url = !empty($full_query_string) ? $endpoint . '?' . $full_query_string : $endpoint;
+        $url = $endpoint;
+        if (!empty($full_query_string)) {
+            $url .= '?' . $full_query_string;
+        }
 
         // Wraps to passed client options.
         $options = [...$this->clientOptions, ...$options];

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -113,7 +113,7 @@ class Client
         if (!empty($query_string)) {
             $full_query_string = !empty($full_query_string) ? $full_query_string . '&' . $query_string : $query_string;
         }
-        $url = $endpoint . '?' . $full_query_string;
+        $url = !empty($full_query_string) ? $endpoint . '?' . $full_query_string : $endpoint;
 
         // Wraps to passed client options.
         $options = [...$this->clientOptions, ...$options];

--- a/tests/Http/ClientTest.php
+++ b/tests/Http/ClientTest.php
@@ -5,6 +5,10 @@ namespace Chromatic\OrangeDam\Http;
 use Chromatic\OrangeDam\Exceptions\InvalidArgumentException;
 use Chromatic\OrangeDam\Exceptions\OrangeDamException;
 use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
 use PHPUnit\Framework\TestCase;
 
 final class ClientTest extends TestCase
@@ -52,5 +56,22 @@ final class ClientTest extends TestCase
         $client->setOauth2Token('example-token');
         $this->assertTrue($client->oauth2);
         $this->assertSame('example-token', $client->token);
+    }
+
+    public function testRequestUrlHasNoTrailingQuestionMark(): void
+    {
+        $container = [];
+        $history = Middleware::history($container);
+        $mock = new MockHandler([new GuzzleResponse(200)]);
+        $handlerStack = HandlerStack::create($mock);
+        $handlerStack->push($history);
+
+        $guzzle = new GuzzleClient(['handler' => $handlerStack, 'base_uri' => 'https://test.com']);
+        $client = new Client(['base_path' => 'https://test.com'], $guzzle);
+        $client->token = 'test-token';
+        $client->request('get', '/some/endpoint');
+
+        $uri = (string) $container[0]['request']->getUri();
+        $this->assertStringNotContainsString('?', $uri);
     }
 }


### PR DESCRIPTION
## Description
Avoid trailing ? when no query string present

## Motivation / Context
Fix edge case

## Testing Instructions / How This Has Been Tested
Tests should pass. Blocked by #54 
