### PR TITLE
fix: call getData() in toArray() to trigger lazy loading

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -73,7 +73,7 @@ class Response implements ResponseInterface
      */
     public function toArray()
     {
-        return json_decode(json_encode($this->data, JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);
+        return json_decode(json_encode($this->getData(), JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);
     }
 
     /**

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -89,4 +89,14 @@ final class ResponseTest extends TestCase
         $response = new Response($clientMock, 'GET', '/');
         $this->assertFalse($response->isEmpty());
     }
+
+    public function testToArrayReturnsDataWithoutCallingGetDataFirst(): void
+    {
+        $clientStub = $this->createStub(GuzzleClient::class);
+        $clientStub->method('request')
+            ->willReturn(new GuzzleResponse(200, [], '{"foo":"bar"}'));
+        $response = new Response($clientStub, 'GET', '/');
+        // Do NOT call getData() first — that's the point of this test
+        $this->assertSame(['foo' => 'bar'], $response->toArray());
+    }
 }


### PR DESCRIPTION
## Description

fix: call getData() in toArray() to trigger lazy loading

## Motivation / Context
Lazy loading was being bypassed

## Testing Instructions / How This Has Been Tested
Tests should pass
